### PR TITLE
export BarcodeFormat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,24 @@
 import {NativeModules} from 'react-native';
 
 export default NativeModules.AnylineSDKPlugin;
+
+// based on strings from BarcodeScanView.BarcodeFormat
+export const BarcodeFormat = {
+  0: 'UNKNOWN',
+  [1 << 0]: 'AZTEC',
+  [1 << 1]: 'CODABAR',
+  [1 << 2]: 'CODE_39',
+  [1 << 3]: 'CODE_93',
+  [1 << 4]: 'CODE_128',
+  [1 << 5]: 'DATA_MATRIX',
+  [1 << 6]: 'EAN_8',
+  [1 << 7]: 'EAN_13',
+  [1 << 8]: 'ITF',
+  [1 << 9]: 'PDF_417',
+  [1 << 10]: 'QR_CODE',
+  [1 << 11]: 'RSS_14',
+  [1 << 12]: 'RSS_EXPANDED',
+  [1 << 13]: 'UPC_A',
+  [1 << 14]: 'UPC_E',
+  [1 << 15]: 'UPC_EAN_EXTENSION'
+}

--- a/ios/AnylineBarcodeScanViewController.m
+++ b/ios/AnylineBarcodeScanViewController.m
@@ -34,19 +34,18 @@
 
 - (void)anylineBarcodeModuleView:(AnylineBarcodeModuleView *)anylineBarcodeModuleView
                didFindScanResult:(NSString *)scanResult
-                   barcodeFormat:(NSString *)barcodeFormat
+               withBarcodeFormat:(ALBarcodeFormat)barcodeFormat
                          atImage:(UIImage *)image {
-
     self.scannedLabel.text = scanResult;
     [self flashResultFor:0.9];
-    
+
     NSMutableDictionary *dictResult = [NSMutableDictionary dictionaryWithCapacity:2];
-    
+
     [dictResult setObject:scanResult forKey:@"value"];
-    [dictResult setObject:barcodeFormat forKey:@"barcodeFormat"];
-    
+    [dictResult setObject:@(barcodeFormat) forKey:@"barcodeFormat"];
+
     NSString *imagePath = [self saveImageToFileSystem:image];
-    
+
     [dictResult setValue:imagePath forKey:@"imagePath"];
     [dictResult setValue:[self base64StringFromImage:image] forKey:@"cutoutBase64"];
   


### PR DESCRIPTION
On second thought, I see in the Java implementation, you pass the enumVal.toString() back. Is that the preference?