### PR TITLE
ResultReporter not called used during finishWithError

### DIFF
--- a/plugin/android/src/main/java/com/anyline/reactnative/AnylineBaseActivity.java
+++ b/plugin/android/src/main/java/com/anyline/reactnative/AnylineBaseActivity.java
@@ -72,6 +72,7 @@ public abstract class AnylineBaseActivity extends Activity
         Intent data = new Intent();
         data.putExtra(AnylineSDKPlugin.EXTRA_ERROR_MESSAGE, errorMessage);
         setResult(AnylineSDKPlugin.RESULT_ERROR, data);
+	ResultReporter.onError(errorMessage);
         finish();
     }
 


### PR DESCRIPTION
Fixes issue where promises not rejected on Android due to ResultReporter not being used during finishWithError. Activity would be closed without promises being resolved.