### PR TITLE
Possible fix for #66

### DIFF
--- a/plugin/ios/AnylineReact.podspec
+++ b/plugin/ios/AnylineReact.podspec
@@ -21,4 +21,5 @@ Pod::Spec.new do |s|
   s.source_files  = "*.{h,m}"
 
   s.dependency "Anyline", "~> 10.1"
+  s.dependency "React"
 end


### PR DESCRIPTION
This fixes the "'React/RCTDefines.h' file not found" issue that we encountered and was confirmed by @JonasLaux 

I'm not sure if this is an acceptable permanent fix or what the implications of doing this are, but it seems to work.