### PR TITLE
[SDKY-564] Clear NativeBarcodeResult after every scan

### DIFF
--- a/plugin/android/src/main/java/com/anyline/reactnative/Anyline4Activity.java
+++ b/plugin/android/src/main/java/com/anyline/reactnative/Anyline4Activity.java
@@ -249,8 +249,6 @@ public class Anyline4Activity extends AnylineBaseActivity {
                                         jsonMeterResult = AnylinePluginHelper.jsonHelper(Anyline4Activity.this, subResult,
                                                 jsonMeterResult);
                                         jsonResult.put(subResult.getPluginId(), jsonMeterResult);
-                                        AnylinePluginHelper.clearFinalBarcodeList();    // otherwise result from previous scan could be shown if new scan does not include barcode
-
                                     } catch (Exception e) {
                                         Log.e(TAG, "EXCEPTION", e);
                                     }
@@ -437,10 +435,13 @@ public class Anyline4Activity extends AnylineBaseActivity {
                             }
 
                             setResult(scanViewPlugin, jsonResult);
-                            AnylinePluginHelper.clearFinalBarcodeList();    // otherwise result from previous scan could be shown if new scan does not include barcode
                         }
                     });
                 }
+
+                /* Clear NativeBarcodeResult after every scan, otherwise the result from previous
+                 * scan would be shown if now barcode was found */
+                AnylinePluginHelper.clearFinalBarcodeList();
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
Clear NativeBarcodeResult after every scan to fix old results being "cached" and reused if a new result doesn't also contain new a new barcode result.