### PR TITLE
[SOCA-460] Deprecate Meter Scan Modes

### DIFF
--- a/example/RNExampleApp/config/AnalogMeterConfig.js
+++ b/example/RNExampleApp/config/AnalogMeterConfig.js
@@ -12,7 +12,7 @@ export default {
             "plugin": {
                 "id": "Meter_ID",
                 "meterPlugin": {
-                    "scanMode": "ANALOG_METER"
+                    "scanMode": "AUTO_ANALOG_DIGITAL_METER"
                 }
             },
             "cutoutConfig": {

--- a/example/RNExampleApp/config/DigitalMeterConfig.js
+++ b/example/RNExampleApp/config/DigitalMeterConfig.js
@@ -12,7 +12,7 @@ export default {
             "plugin": {
                 "id": "DIGITAL_METER",
                 "meterPlugin": {
-                    "scanMode": "DIGITAL_METER"
+                    "scanMode": "AUTO_ANALOG_DIGITAL_METER"
                 }
             },
             "cutoutConfig": {

--- a/example/RNExampleApp/config/DotMatrixConfig.js
+++ b/example/RNExampleApp/config/DotMatrixConfig.js
@@ -12,7 +12,7 @@ export default {
             "plugin": {
                 "id": "Meter_ID",
                 "meterPlugin": {
-                    "scanMode": "DOT_MATRIX_METER"
+                    "scanMode": "AUTO_ANALOG_DIGITAL_METER"
                 }
             },
             "cutoutConfig": {


### PR DESCRIPTION
... the following Meter Scan Modes are deprecated now: ANALOG_METER, DIGITAL_METER, DOT_MATRIX_METER. They are being replaced with AUTO_ANALOG_DIGITAL_METER.